### PR TITLE
Add `isValidSignatureWithSender` and tests for valid/invalid cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/
 # Dotenv file
 .env
 node_modules
+.vscode

--- a/src/IAMValidator.sol
+++ b/src/IAMValidator.sol
@@ -122,8 +122,9 @@ contract IAMValidator is ERC7579ValidatorBase {
         override
         returns (bytes4 sigValidationResult)
     {
-        (uint24 signerId, uint256 r, uint256 s) = abi.decode(signature, (uint24, uint256, uint256));
-        (uint8 installCount,,) = _parseCounter(Counters[msg.sender]);
+        (uint120 signerId, uint256 r, uint256 s) =
+            abi.decode(signature, (uint120, uint256, uint256));
+        (uint16 installCount,,) = _parseCounter(Counters[msg.sender]);
         Signer memory signer =
             SignerRegister[_packInstallCountAndSignerId(installCount, signerId)][msg.sender];
 

--- a/test/Authentication.t.sol
+++ b/test/Authentication.t.sol
@@ -65,21 +65,25 @@ contract AuthenticationTest is TestHelper {
     }
 
     function testERC1271ValidSignature() public virtual {
-        bytes32 hash = keccak256("0xdead");
-        (bytes32 r, bytes32 s) = vm.signP256(testP256PrivateKeyRoot, hash);
+        bytes32 rawHash = keccak256("0xdead");
+        bytes32 formattedHash = _formatERC1271Hash(address(validator), rawHash);
+
+        (bytes32 r, bytes32 s) = vm.signP256(testP256PrivateKeyRoot, formattedHash);
         bytes memory signature = abi.encode(rootSignerId, uint256(r), uint256(s));
 
-        bool valid = _verifyEIP1271Signature(address(validator), hash, signature);
+        bool valid = _verifyERC1271Signature(address(validator), rawHash, signature);
 
         assertTrue(valid);
     }
 
     function testERC1271InValidSignature() public virtual {
-        bytes32 hash = keccak256("0xdead");
-        (bytes32 r, bytes32 s) = vm.signP256(testP256PrivateKey2, hash);
+        bytes32 rawHash = keccak256("0xdead");
+        bytes32 formattedHash = _formatERC1271Hash(address(validator), rawHash);
+
+        (bytes32 r, bytes32 s) = vm.signP256(testP256PrivateKey1, formattedHash);
         bytes memory signature = abi.encode(rootSignerId, uint256(r), uint256(s));
 
-        bool valid = _verifyEIP1271Signature(address(validator), hash, signature);
+        bool valid = _verifyERC1271Signature(address(validator), rawHash, signature);
 
         assertFalse(valid);
     }

--- a/test/TestHelper.sol
+++ b/test/TestHelper.sol
@@ -57,15 +57,19 @@ abstract contract TestHelper is RhinestoneModuleKit, Test {
         userOpData.execUserOps();
     }
 
-    function _verifyEIP1271Signature(
-        address sender,
+    function _formatERC1271Hash(address validator, bytes32 hash) internal returns (bytes32) {
+        return instance.formatERC1271Hash(validator, hash);
+    }
+
+    function _verifyERC1271Signature(
+        address validator,
         bytes32 hash,
         bytes memory signature
     )
         internal
         returns (bool)
     {
-        return instance.isValidSignature(sender, hash, signature);
+        return instance.isValidSignature({ validator: validator, hash: hash, signature: signature });
     }
 
     function _installModule() internal {


### PR DESCRIPTION
- Implemented `isValidSignatureWithSender` for signature validation.
- Decoded signature components and verified against `SignerRegister`.
- Included tests to cover both passing and failing scenarios.