### PR TITLE
Use the full 32 byte storage slot for counters

### DIFF
--- a/test/Authentication.t.sol
+++ b/test/Authentication.t.sol
@@ -7,7 +7,7 @@ import { Signer } from "src/Signer.sol";
 
 contract AuthenticationTest is TestHelper {
     function testAddSignerWritesToState() public {
-        uint24 expectedSignerId = rootSignerId + 1;
+        uint120 expectedSignerId = rootSignerId + 1;
         Signer memory s = validator.getSigner(address(instance.account), expectedSignerId);
         assertEqUint(s.x, 0);
         assertEqUint(s.y, 0);
@@ -26,19 +26,19 @@ contract AuthenticationTest is TestHelper {
     }
 
     function testAddSignerEmitsEvent() public {
-        uint24 expectedSignerId = 0;
+        uint120 expectedSignerId = 0;
         vm.expectEmit(true, true, true, true, address(validator));
         emit SignerAdded(address(this), expectedSignerId, testP256PubKeyX1, testP256PubKeyY1);
         validator.addSigner(testP256PubKeyX1, testP256PubKeyY1);
 
-        uint24 expectedSignerId1 = 1;
+        uint120 expectedSignerId1 = 1;
         vm.expectEmit(true, true, true, true, address(validator));
         emit SignerAdded(address(this), expectedSignerId1, testP256PubKeyX2, testP256PubKeyY2);
         validator.addSigner(testP256PubKeyX2, testP256PubKeyY2);
     }
 
     function testRemoveSignerWritesToState() public {
-        uint24 expectedSignerId = rootSignerId + 1;
+        uint120 expectedSignerId = rootSignerId + 1;
         _execUserOp(
             address(validator),
             0,
@@ -58,7 +58,7 @@ contract AuthenticationTest is TestHelper {
     }
 
     function testRemoveSignerEmitsEvent() public {
-        uint24 expectedSignerId = 0;
+        uint120 expectedSignerId = 0;
         vm.expectEmit(true, true, true, true, address(validator));
         emit SignerRemoved(address(this), expectedSignerId);
         validator.removeSigner(expectedSignerId);

--- a/test/TestHelper.sol
+++ b/test/TestHelper.sol
@@ -13,8 +13,8 @@ import { MODULE_TYPE_VALIDATOR } from "modulekit/external/ERC7579.sol";
 import { IAMValidator } from "src/IAMValidator.sol";
 
 abstract contract TestHelper is RhinestoneModuleKit, Test {
-    event SignerAdded(address indexed account, uint24 indexed signerId, uint256 x, uint256 y);
-    event SignerRemoved(address indexed account, uint24 indexed signerId);
+    event SignerAdded(address indexed account, uint120 indexed signerId, uint256 x, uint256 y);
+    event SignerRemoved(address indexed account, uint120 indexed signerId);
 
     using ModuleKitHelpers for *;
     using ModuleKitUserOp for *;
@@ -29,7 +29,7 @@ abstract contract TestHelper is RhinestoneModuleKit, Test {
         0xf24b7cd0e0d84317f2fbba39add412ddd3df7cb84be213b67fb340373e9275ec;
     uint256 constant testP256PublicKeyYRoot =
         0x255417d4c6780a9db69e2023685c95a344f3e59e930e758f3829b0b10bf87ebc;
-    uint24 constant rootSignerId = 0;
+    uint120 constant rootSignerId = 0;
 
     uint256 constant testP256PrivateKey1 =
         0x605e0a63a358c3060f9ea4b3ee7737f21e4dc49755f90ae4ad12ffcbe71a26ef;


### PR DESCRIPTION
It is actually more efficient to use the entire 32 bytes in a storage slot.